### PR TITLE
bytes_to_file

### DIFF
--- a/src/chuk_artifacts/providers/filesystem.py
+++ b/src/chuk_artifacts/providers/filesystem.py
@@ -55,6 +55,26 @@ class _FilesystemClient:
         meta_json = json.dumps(meta_data, indent=2)
         await asyncio.to_thread(meta_path.write_text, meta_json, encoding='utf-8')
 
+    async def _write_bytes_to_file(self, 
+                                   meta_path: Path, 
+                                   Body: bytes, 
+                                   metadata: Dict[str, str]
+                                   ):
+        """
+        Asynchronously write byte data to a file using pathlib.
+
+        Args:
+            meta_path: The base directory where the file should be saved.
+            Body: The byte content to write.
+            metadata: Dictionary containing at least the 'filename' key.
+        """
+        if 'filename' not in metadata:
+            raise ValueError("metadata must include a 'filename' key")
+        target_dir = meta_path.parent
+        file_path = target_dir / metadata['filename']
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(file_path.write_bytes, Body)
+
     async def _read_metadata(self, meta_path: Path) -> Dict[str, Any]:
         """Read metadata file."""
         try:
@@ -90,6 +110,8 @@ class _FilesystemClient:
             await self._ensure_parent_dir(object_path)
             # Write the main object file
             await asyncio.to_thread(object_path.write_bytes, Body)
+            # Write the bytes object to file based on metadata info
+            await self._write_bytes_to_file(meta_path=object_path,Body=Body,metadata=Metadata)
             # Write the metadata file
             await self._write_metadata(meta_path, ContentType, Metadata, len(Body), etag)
 


### PR DESCRIPTION
added function to write bytes to file based on metadata info. Have tested. It has created file with extension based on metadata info (name & file format) in the same location where metadata.json  and bytes object were created.  Please review